### PR TITLE
fix: add scope (public/private) selection when saving SQL

### DIFF
--- a/frontend/src/components/Main/Explore/QueryConsole/SaveSnippetDialog.vue
+++ b/frontend/src/components/Main/Explore/QueryConsole/SaveSnippetDialog.vue
@@ -4,11 +4,16 @@
     :title="$tc('SaveSQL')"
     :visible.sync="iVisible"
     :modal="false"
+    :append-to-body="true"
     width="40%"
   >
     <el-form ref="form" :model="form" label-width="80px">
       <el-form-item :label="$tc('Name')">
         <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item :label="$tc('Scope')">
+        <el-radio v-model="form.scope" label="private">{{ $tc('Private') }}</el-radio>
+        <el-radio v-model="form.scope" label="public">{{ $tc('Public') }}</el-radio>
       </el-form-item>
     </el-form>
 
@@ -39,7 +44,8 @@ export default {
   data() {
     return {
       form: {
-        name: ''
+        name: '',
+        scope: 'private'
       }
     }
   },
@@ -69,7 +75,8 @@ export default {
       axios.post('/api/v1/ops/adhocs/', {
         name: this.form.name,
         args: this.content,
-        module: store.getters.profile?.dbType
+        module: store.getters.profile?.dbType,
+        scope: this.form.scope
       }, {
         headers: {
           'X-CSRFToken': csrfToken

--- a/frontend/src/i18n/langs/en.json
+++ b/frontend/src/i18n/langs/en.json
@@ -7,6 +7,8 @@
     "notAlphanumericUnderscore": "Only alphanumeric characters and underscores are allowed.",
     "notParenthesis": "Parentheses are not allowed.",
     "InvalidJson": "Invalid JSON format.",
-    "requiredHasUserNameMapped": "Username attr is required."
+    "requiredHasUserNameMapped": "Username attr is required.",
+    "Public": "Public",
+    "Private": "Private"
 }
 

--- a/frontend/src/i18n/langs/ja.json
+++ b/frontend/src/i18n/langs/ja.json
@@ -7,5 +7,7 @@
     "notAlphanumericUnderscore": "仅支持字母、数字和下划线。",
     "notParenthesis": "不能包含括号。",
     "InvalidJson": "JSON 格式错误.",
-    "requiredHasUserNameMapped": "用户名属性是必需的。"
+    "requiredHasUserNameMapped": "用户名属性是必需的。",
+    "Public": "公開",
+    "Private": "非公開"
 }

--- a/frontend/src/i18n/langs/zh.json
+++ b/frontend/src/i18n/langs/zh.json
@@ -7,5 +7,7 @@
     "notAlphanumericUnderscore": "仅支持字母、数字和下划线。",
     "notParenthesis": "不能包含括号。",
     "InvalidJson": "JSON 格式错误.",
-    "requiredHasUserNameMapped": "用户名属性是必需的。"
+    "requiredHasUserNameMapped": "用户名属性是必需的。",
+    "Public": "公有",
+    "Private": "私有"
 }

--- a/frontend/src/i18n/langs/zh_Hant.json
+++ b/frontend/src/i18n/langs/zh_Hant.json
@@ -7,5 +7,7 @@
     "notAlphanumericUnderscore": "仅支持字母、数字和下划线。",
     "notParenthesis": "不能包含括号。",
     "InvalidJson": "JSON 格式错误.",
-    "requiredHasUserNameMapped": "用户名属性是必需的。"
+    "requiredHasUserNameMapped": "用户名属性是必需的。",
+    "Public": "公有",
+    "Private": "私有"
 }


### PR DESCRIPTION
在 Chen 中保存 SQL 片段时，前端 POST 到 `/api/v1/ops/adhocs/` 的请求体里没有 `scope` 字段。Core 的 `AdHocSerializer` 中 `scope` 默认为 `public`，导致每条保存的 SQL 都变成公有、对所有用户可见，存在数据泄露风险；用户也无法选择可见范围。

改动： SaveSnippetDialog.vue
新增范围单选：私有 / 公有
默认 私有（默认即安全）
创建请求中带上 scope